### PR TITLE
fix: comments link for Web API post by changing title 

### DIFF
--- a/src/posts/2021-02-25-web-apis.md
+++ b/src/posts/2021-02-25-web-apis.md
@@ -1,5 +1,5 @@
 ---
-title: Moderne web API's
+title: Moderne web APIs
 tags: Browser API's, Web Bluetooth, WebUSB, Web Serial,
 comments: true
 author: youri


### PR DESCRIPTION
Fixed bug where the comments counter was empty underneath the title of a post.
Fixes #149 