### PR TITLE
ci: fix broken link checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "rimraf dist && eleventy --serve",
     "check-broken-links": "npm run check-broken-links:internal && npm run check-broken-links:external",
     "check-broken-links:internal": "npx broken-link-checker-local ./dist -roe --filter-level 3 --exclude \"*/__/firebase/*\"",
-    "check-broken-links:external": "npx broken-link-checker-local ./dist -roi --filter-level 3 --exclude \"*/__/firebase/*\""
+    "check-broken-links:external": "npx broken-link-checker-local ./dist -roi --filter-level 3 --exclude \"*/__/firebase/*\"  --exclude \"*/stenciljs.com/*\""
   },
   "repository": {
     "type": "git",

--- a/src/_data/io21_workshops.json
+++ b/src/_data/io21_workshops.json
@@ -2,49 +2,49 @@
   {
     "title": "Extend an Android app to Google Assistant with App Actions",
     "topic": "Android & Google Assistant",
-    "url": "https://events.google.com/io/session/1173ce49-233b-460c-96e9-ed094738dde0?lng=en",
+    "url": "https://events.google.com/io#/session/1173ce49-233b-460c-96e9-ed094738dde0?lng=en",
     "video_url": "https://youtu.be/PMinB3VZ9x4",
     "codelab_url": "https://codelabs.developers.google.com/codelabs/appactions-beta"
   },
   {
     "title": "Build and deploy a model with Vertex AI",
     "topic": "Cloud & ML/AI",
-    "url": "https://events.google.com/io/session/a0414a2a-b43f-449b-b248-1d8cb765159c?lng=en",
+    "url": "https://events.google.com/io#/session/a0414a2a-b43f-449b-b248-1d8cb765159c?lng=en",
     "video_url": "https://youtu.be/aB2OxnyfP0c",
     "codelab_url": "https://codelabs.developers.google.com/codelabs/vertex-ai-custom-models"
   },
   {
     "title": "Build user-adaptive interfaces with preference media",
     "topic": "Web",
-    "url": "https://events.google.com/io/session/f09c3e3e-f64e-4551-a948-9a718588a463?lng=en",
+    "url": "https://events.google.com/io#/session/f09c3e3e-f64e-4551-a948-9a718588a463?lng=en",
     "video_url": "https://youtu.be/NQ-FQvsR-gY",
     "codelab_url": "https://codelabs.developers.google.com/codelabs/user-adaptive-interfaces"
   },
   {
     "title": "Create your first Tile in Wear",
     "topic": "Android Wear",
-    "url": "https://events.google.com/io/session/fbef3692-047b-4573-b345-7d40388ff568?lng=en",
+    "url": "https://events.google.com/io#/session/fbef3692-047b-4573-b345-7d40388ff568?lng=en",
     "video_url": "https://youtu.be/Q7xudRfN188",
     "codelab_url": "https://developer.android.com/codelabs/wear-tiles"
   },
   {
     "title": "TensorFlow.js: Make a smart webcam in JS with a pre-trained ML model",
     "topic": "IoT/SmartHome & TensorFlow",
-    "url": "https://events.google.com/io/session/8472f8a3-619a-47cb-b606-8a451175a344?lng=en",
+    "url": "https://events.google.com/io#/session/8472f8a3-619a-47cb-b606-8a451175a344?lng=en",
     "video_url": "https://youtu.be/hk-709L3RK8",
     "codelab_url": "https://codelabs.developers.google.com/codelabs/tensorflowjs-object-detection"
   },
   {
     "title": "A whirlwind tour through Project Fugu APIs",
     "topic": "Web",
-    "url": "https://events.google.com/io/session/af611a1c-b490-4514-8e0d-0b64200409f4?lng=en",
+    "url": "https://events.google.com/io#/session/af611a1c-b490-4514-8e0d-0b64200409f4?lng=en",
     "video_url": "https://youtu.be/5CLyAX2CTLc",
     "codelab_url": "https://developers.google.com/codelabs/project-fugu"
   },
   {
     "title": "Get to know Firebase for Flutter",
     "topic": "Firebase & Flutter",
-    "url": "https://events.google.com/io/session/86b5dda1-cad1-47f9-bd36-b84674dad014?lng=en",
+    "url": "https://events.google.com/io#/session/86b5dda1-cad1-47f9-bd36-b84674dad014?lng=en",
     "video_url": "https://youtu.be/4wunbF29Kkg",
     "codelab_url": "https://firebase.google.com/codelabs/firebase-get-to-know-flutter"
   }

--- a/src/posts/2021-05-21-google-io-learn-something-new.md
+++ b/src/posts/2021-05-21-google-io-learn-something-new.md
@@ -19,7 +19,7 @@ Het is de week van Google I/O, een week vol inspiratie waarin Google de laatste 
 
 [Google I/O](https://events.google.com/io/) is het grootste 3-daagse developers event van Google, live vanuit [Mountain View (California)](<https://nl.wikipedia.org/wiki/Mountain_View_(Santa_Clara_County)>). Dit jaarlijkse evenement is dit jaar voor het eerst volledig virtueel.
 
-Het evenement is gevuld met keynotes, sessies, workshops en meer. Er is zelfs een virtuele wereld ([Google I/O Adventure](https://events.google.com/io/adventure?lng=en)) waarin je met andere developers en Googlers kan connecten.
+Het evenement is gevuld met keynotes, sessies, workshops en meer. Er is zelfs een virtuele wereld ([Google I/O Adventure](https://events.google.com/io#/adventure?lng=en)) waarin je met andere developers en Googlers kan connecten.
 
 ![Google I/O Adventure](/assets/io-codelabs/io21-adventure.png)
 
@@ -29,13 +29,13 @@ Diverse onderwerpen komen voorbij, zoals Firebase, Accessibility, Android en nog
 
 ![Google Products](/assets/io-codelabs/io21-products.png)
 
-Bekijk de [event website](https://events.google.com/io/program/discover/) om het volledige programma te verkennen.
+Bekijk de [event website](https://events.google.com/io#/program/discover/) om het volledige programma te verkennen.
 
 <!-- Section: Workshops & Codelabs -->
 
 ### Google Workshops & Codelabs
 
-Het is tijdens het evenement ook mogelijk om deel te nemen aan een of meerdere workshops. Iedere workshop wordt verzorgt door een Googler en neemt ongeveer een uur in beslag. Letterlijk voor ieder product of onderwerp is er wel een workshop beschikbaar. Kijk maar eens op de website onder het kopje [Learning Lab](https://events.google.com/io/learning-lab/?lng=en).
+Het is tijdens het evenement ook mogelijk om deel te nemen aan een of meerdere workshops. Iedere workshop wordt verzorgt door een Googler en neemt ongeveer een uur in beslag. Letterlijk voor ieder product of onderwerp is er wel een workshop beschikbaar. Kijk maar eens op de website onder het kopje [Learning Lab](https://events.google.com/io#/learning-lab/?lng=en).
 
 ![Google I/O Workshops](/assets/io-codelabs/io21-workshops.png)
 
@@ -81,6 +81,6 @@ Hopelijk ben je hiermee geinspireerd geraakt om zelf ook eens een workshop of co
 ### Externe links
 
 - [Google I/O Keynote](https://www.youtube.com/watch?v=XFFrahd05OM)
-- [Google I/O website](https://events.google.com/io/?lng=en)
+- [Google I/O website](https://events.google.com/io/)
 - [Google Developers](https://developers.google.com/)
 - [web.dev](https://web.dev/)


### PR DESCRIPTION
* update events.google.com/io links
* exclude stenciljs.com domain from scanning