### PR TITLE
ci: migrate to trunk-based development

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,9 +118,12 @@ npm run check-broken-links:external  # External links only (slower)
 
 ## CI/CD Pipeline Notes
 
+- **Branch model**: Trunk-based — feature branches branch off `main`, PRs target `main`
 - **Build job**: Runs on Node.js 24, uses `npm ci` and `npm run build`
 - **Link checking**: Only internal links are checked in CI
-- **Deployment**: Automatic to Firebase hosting on develop/main branches
+- **PR previews**: Every PR deploys to a Firebase preview channel (`ci.yml`)
+- **Deployment**: Every push to `main` deploys automatically to production Firebase hosting (`deploy-production.yml`; manual redeploy via workflow_dispatch)
+- **Releases**: semantic-release creates a GitHub Release + tag on release-worthy commits (`feat:`/`fix:`); deploys do NOT depend on releases and `CHANGELOG.md` is frozen
 - **Artifact**: dist/ directory is archived and deployed
 
 ## Technology Stack Details

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,68 @@
+# Managed by galaxy-brain — regenerate with `audit-dependabot` or edit deliberately.
+# Source: discipline-frontend/galaxy-brain.yml § standards.dependabot
+# Project extensions (documented in project-geekbites/galaxy-brain.yml → standards-override):
+#   - `automerge` label (consumed by .github/workflows/automerge.yml)
+#   - `eleventy` group (project stack; not part of the discipline recipes)
 version: 2
+
 updates:
-  # Configuration for npm
   - package-ecosystem: 'npm'
-    directory: .
+    directory: '/'
     schedule:
-      # Check the npm registry for updates at 4am UTC
-      interval: 'daily'
-      time: '04:00'
-    open-pull-requests-limit: 20
-    target-branch: 'integration/dependabot'
+      interval: 'weekly'
+      day: 'monday'
+      time: '07:00'
+      timezone: 'Europe/Amsterdam'
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'automerge'
+    cooldown:
+      default-days: 3
+      semver-patch-days: 2
+      semver-minor-days: 4
+      semver-major-days: 5
+      exclude:
+        - '@angular/*'
+        - '@angular-devkit/*'
+        - '@angular-builders/*'
+        - '@schematics/angular'
+        - '@nx/*'
+        - 'nx'
+    groups:
+      eleventy:
+        applies-to: version-updates
+        patterns:
+          - '@11ty/*'
+      release-tools:
+        applies-to: version-updates
+        patterns:
+          - '@semantic-release/*'
+          - 'semantic-release'
+          - '@commitlint/*'
+          - 'commitlint'
+          - 'commitizen'
+          - 'husky'
+          - 'lint-staged'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '07:00'
+      timezone: 'Europe/Amsterdam'
+    open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+      - 'automerge'
+    cooldown:
+      default-days: 3
+      semver-patch-days: 2
+      semver-minor-days: 4
+      semver-major-days: 5
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Check cache
+        uses: actions/cache@v4
+        id: node-cache # use this to check for `cache-hit` (`steps.node-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: '**/node_modules'
+          key: ubuntu-latest-node-modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install node modules
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci
+        env:
+          CI: true
+
+      - name: Build artifact
+        run: npm run build
+
+      - name: Check for broken links
+        run: npm run check-broken-links:internal
+
+      - name: Archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: dist
+
+  CreatePreview:
+    name: Generate Preview URL
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+    needs: [Build]
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    environment:
+      name: Preview Channels
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifacts
+          path: dist
+
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
+          projectId: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,10 +18,10 @@ permissions:
 
 on:
   push:
-    branches: [develop, main]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [develop]
+    branches: [main]
   schedule:
     - cron: '21 21 * * 0'
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,24 +1,18 @@
-name: Default Workflow
+name: Deploy Production
 
 on:
   push:
-    branches: [develop, main]
-  pull_request:
-    branches: [develop, main]
+    branches: [main]
   workflow_dispatch:
+
 jobs:
   Build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
           persist-credentials: false
 
       - name: Use Node.js from .nvmrc
@@ -51,59 +45,12 @@ jobs:
           name: artifacts
           path: dist
 
-  CreatePreview:
-    name: Generate Preview URL
-    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
-    needs: [Build]
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: write
-    environment:
-      name: Preview Channels
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: artifacts
-          path: dist
-
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
-          projectId: ${{ secrets.FIREBASE_PROJECT_ID }}
-
-  DeployDevelopment:
-    name: Deploy to Development
-    if: github.event.ref == 'refs/heads/develop'
-    needs: [Build]
-    runs-on: ubuntu-latest
-    environment:
-      name: Development
-      url: 'https://dev.geekbites.move4mobile.io'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: artifacts
-          path: dist
-
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
-          projectId: ${{ secrets.FIREBASE_PROJECT_ID }}
-          channelId: live
-
   DeployProduction:
     name: Deploy to Production
-    needs: [CreateRelease]
+    needs: [Build]
     runs-on: ubuntu-latest
     environment:
-      name: Production
+      name: production
       url: 'https://geekbites.move4mobile.io'
     steps:
       - uses: actions/checkout@v4
@@ -122,14 +69,10 @@ jobs:
 
   CreateRelease:
     name: Create Release
-    if: ${{ github.event.ref == 'refs/heads/main' && ! contains(github.event.head_commit.message, '[skip-ci]') }}
+    # Only on push — a manual redeploy (workflow_dispatch) should never cut a release.
+    if: github.event_name == 'push'
     needs: [Build]
-
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -160,12 +103,9 @@ jobs:
         env:
           CI: true
 
-      - name: Prepare artifacts folder
-        working-directory: ${{ github.workspace }}
-        run: mkdir artifacts
-
-      - name: Build artifact
+      - name: Zip site artifact
         run: |
+          mkdir -p artifacts
           zip -r ./artifacts/site ./dist/*
 
       - name: Semantic release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+> **This changelog is frozen as of v2.15.0.** Release notes now live on the
+> [GitHub Releases page](https://github.com/move-frontend/geekbites/releases),
+> generated automatically by semantic-release on every release-worthy merge to `main`.
+
 # [2.15.0](https://github.com/move4mobile/geekbites/compare/v2.14.1...v2.15.0) (2025-07-13)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,11 @@ Geek Bites is a static blog site built with Eleventy (11ty) for Move4Mobile deve
 - Posts automatically get "posts" tag and use post layout
 - Permalink structure: `{{ date | ymd }}/{{ title | slugify }}/`
 
-### Deployment
+### Deployment & Branch Model
+- Trunk-based development: feature branches → PR → `main` (no develop branch)
+- Every PR gets a Firebase preview channel; every push to `main` auto-deploys to production (`deploy-production.yml`)
+- semantic-release creates GitHub Releases + tags on `feat:`/`fix:` merges; deploys do not depend on releases; `CHANGELOG.md` is frozen
 - Firebase hosting configured (firebase.json)
-- Semantic release configured for automated versioning
 - Husky hooks for commit message linting (conventional commits)
 
 ### Data Sources

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -47,9 +47,11 @@ Geek Bites is a static blog site built with Eleventy (11ty) for Move4Mobile deve
 - Posts automatically get "posts" tag and use post layout
 - Permalink structure: `{{ date | ymd }}/{{ title | slugify }}/`
 
-### Deployment
+### Deployment & Branch Model
+- Trunk-based development: feature branches → PR → `main` (no develop branch)
+- Every PR gets a Firebase preview channel; every push to `main` auto-deploys to production (`deploy-production.yml`)
+- semantic-release creates GitHub Releases + tags on `feat:`/`fix:` merges; deploys do not depend on releases; `CHANGELOG.md` is frozen
 - Firebase hosting configured (firebase.json)
-- Semantic release configured for automated versioning
 - Husky hooks for commit message linting (conventional commits)
 
 ### Data Sources

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
         "@commitlint/cli": "^21.2.0",
         "@commitlint/config-conventional": "^21.2.0",
-        "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^13.0.1",
-        "@semantic-release/git": "^10.0.1",
-        "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^14.1.1",
         "broken-link-checker-local": "^0.2.1",
         "cz-conventional-changelog": "^3.3.0",
@@ -1278,25 +1275,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@semantic-release/changelog": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
-      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash": "^4.17.4"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
@@ -1318,39 +1296,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
-      }
-    },
-    "node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@semantic-release/git": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.0",
-        "p-reduce": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
       }
     },
     "node_modules/@semantic-release/github": {
@@ -1909,20 +1854,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ajv": {
@@ -2833,16 +2764,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cli-cursor": {
@@ -4268,43 +4189,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/execa/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -5296,16 +5180,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
     "node_modules/humanize-duration": {
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.34.0.tgz",
@@ -5423,16 +5297,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/index-to-position": {
@@ -7120,19 +6984,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
@@ -9386,16 +9237,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
@@ -11364,16 +11205,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -13,24 +13,21 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/move4mobile/geekbites.git"
+    "url": "https://github.com/move-frontend/geekbites.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/move4mobile/geekbites/issues"
+    "url": "https://github.com/move-frontend/geekbites/issues"
   },
-  "homepage": "https://github.com/move4mobile/geekbites#readme",
+  "homepage": "https://github.com/move-frontend/geekbites#readme",
   "devDependencies": {
     "@11ty/eleventy": "^3.1.6",
     "@11ty/eleventy-plugin-rss": "^3.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "@commitlint/cli": "^21.2.0",
     "@commitlint/config-conventional": "^21.2.0",
-    "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
-    "@semantic-release/git": "^10.0.1",
-    "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.1",
     "broken-link-checker-local": "^0.2.1",
     "cz-conventional-changelog": "^3.3.0",
@@ -58,23 +55,9 @@
     "branches": [
       "main"
     ],
-    "prepare": [
-      "@semantic-release/changelog",
-      "@semantic-release/npm",
-      {
-        "path": "@semantic-release/git",
-        "assets": [
-          "package.json",
-          "package-lock.json",
-          "CHANGELOG.md"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip-ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/changelog",
       [
         "@semantic-release/github",
         {
@@ -82,9 +65,7 @@
             "artifacts/**"
           ]
         }
-      ],
-      "@semantic-release/npm",
-      "@semantic-release/git"
+      ]
     ]
   }
 }


### PR DESCRIPTION
## What

Migrates Geekbites from gitflow (`develop` + `main`) to trunk-based development. After this PR merges, `main` becomes the default branch and `develop` + `integration/dependabot` will be deleted.

## Why

- Last production release was **v2.15.0 (July 2025)** — the develop→main release step was a manual bottleneck that nobody performed for almost a year ("Next release" PR #549 sat open since March 2026).
- **Deploy bug**: `DeployProduction` depended on `CreateRelease`, so a main merge with only `build`/`chore` commits produced no release and therefore **no production deploy** (happened on #500 and again on #549).
- The last release run failed with `EGITNOPERMISSION`: `package.json → repository.url` still pointed at the old `move4mobile` org.

## Changes

| Area | Change |
|---|---|
| `ci.yml` (new) | PR validation: build + internal link check + Firebase preview channel |
| `deploy-production.yml` (new, replaces `cicd.yml`) | Every push to `main` → build → deploy to production. `workflow_dispatch` as manual redeploy/rollback escape hatch. Deploy no longer depends on the release job |
| semantic-release | Slimmed to `commit-analyzer` + `release-notes-generator` + `github`. No more `chore(release)` commit-back, version bumps or CHANGELOG writes. `CHANGELOG.md` frozen in favor of GitHub Releases |
| `package.json` | `repository.url`/`bugs`/`homepage` → `move-frontend` (fixes the release failure) |
| Dependabot | Weekly grouped updates against `main` per the frontend discipline standard (cooldown, `eleventy`/`release-tools`/`github-actions` groups). `integration/dependabot` funnel retired |
| CodeQL | `develop` references → `main` |
| Docs | README/CLAUDE/GEMINI/copilot-instructions describe the trunk-based model |

## Follow-up (repo settings, after merge)

- [ ] Default branch → `main`
- [ ] Branch protection: copy develop rules to main; delete `develop` + `integration/dependabot`
- [ ] Fix `production` environment deployment branch policy (`release/production` → `main`)
- [ ] Remove unused environments: Development, Acceptance, Test, github-pages

## Test plan

- [x] `npm run build` succeeds locally (Node 24)
- [x] `npm run check-broken-links:internal` — 0 broken
- [x] All workflow YAML parses
- [ ] PR preview channel deploys (this PR)
- [ ] First push to main: production deploy runs independent of release outcome