### PR TITLE
ci: disable semantic-release issue/PR comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
         {
           "assets": [
             "artifacts/**"
-          ]
+          ],
+          "successComment": false,
+          "failComment": false,
+          "failTitle": false
         }
       ]
     ]


### PR DESCRIPTION
## What

Adds `successComment: false`, `failComment: false` and `failTitle: false` to the `@semantic-release/github` plugin options.

## Why

Issues are disabled on this repository. After the v2.16.0 release was published successfully, the plugin's `success` step failed trying to comment on issues/PRs referenced in commit messages (`Could not resolve to an issue or pull request with the number of 486`), marking the Create Release job red even though the release itself succeeded. The `fail` step has the same problem (it tries to open a failure issue → `410 Issues has been disabled`).

## Test plan

- [ ] CI green on this PR
- [ ] Next release-worthy merge to main: Create Release job completes green