### PR TITLE
fix: wire up husky commit-msg hook and update site branding

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "prepare": "husky",
     "build": "eleventy",
     "start": "rimraf dist && eleventy --serve",
     "check-broken-links": "npm run check-broken-links:internal && npm run check-broken-links:external",
@@ -39,11 +40,6 @@
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
-    }
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "commitlint": {

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,6 +1,6 @@
 export default {
   title: 'Geek Bites',
-  description: 'Move4Mobile developers blog',
+  description: 'Framna developer blog',
   url: 'https://geekbites.move4mobile.io/',
   buildTime: new Date()
 };


### PR DESCRIPTION
## What

Wires up the husky commit-msg hook so conventional-commit linting actually runs, and refreshes outdated site branding.

## Why

`package.json` declared `husky` ^9 and a `commitlint` config, but the only hook wiring was a **legacy husky v4-style** `"husky": { "hooks": { ... } }` block that husky v9 ignores. There was no `prepare` script and no `.husky/` directory, so fresh clones got no git hook and bad commit messages were never rejected locally.

Separately, the site description still read `Move4Mobile developers blog`; the blog is Framna's now.

## Changes

- Added `"prepare": "husky"` to `scripts` so `.husky/` is registered on install.
- Removed the ignored legacy `"husky": { ... }` config block from `package.json`.
- Added `.husky/commit-msg` (husky v9 idiom, executable) running `npx --no -- commitlint --edit "$1"`.
- Updated `src/_data/site.js` description to `Framna developer blog`. URL fields left unchanged (`geekbites.move4mobile.io` is still the live production domain).

## Test plan

- [x] Hook rejects a non-conventional message (`git commit -m "bad message"` fails with commitlint `subject-empty` / `type-empty` errors)
- [x] Hook accepts a valid message (`git commit -m "test: hook check"` passes; the real PR commit also passed the hook)
- [x] `git config core.hooksPath` resolves to `.husky/_` after `npm install` ran the prepare script
- [x] `npm run build` succeeds (eleventy wrote 27 files)
