### PR TITLE
ci: drop unsupported semver cooldowns from github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,11 +56,10 @@ updates:
     labels:
       - 'dependencies'
       - 'automerge'
+    # github-actions has no semver semantics for Dependabot cooldowns —
+    # only default-days is supported for this ecosystem.
     cooldown:
       default-days: 3
-      semver-patch-days: 2
-      semver-minor-days: 4
-      semver-major-days: 5
     groups:
       github-actions:
         applies-to: version-updates


### PR DESCRIPTION
## What

Removes the `semver-patch-days`/`semver-minor-days`/`semver-major-days` cooldown keys from the **github-actions** update block in `.github/dependabot.yml`, keeping only `default-days: 3`.

## Why

GitHub rejects the entire config with *"The property '#/updates/1/cooldown/semver-…-days' is not supported for the package ecosystem 'github-actions'"* — semver-granular cooldowns only exist for ecosystems with semver semantics (npm keeps its full cooldown block, unchanged). Introduced in #581.

## Test plan

- [x] YAML parses
- [ ] Dependabot config validation error disappears on the Dependency graph → Dependabot tab after merge